### PR TITLE
VEP-6: Vitess Release Cadence to 6 monthly cycle

### DIFF
--- a/veps/vep-6.md
+++ b/veps/vep-6.md
@@ -1,12 +1,12 @@
 # # VEP-6 Vitess Release cadence
 
 ```
-VEP: 5
+VEP: 6
 Title: Vitess Release Cadence
-Author: Andres Taylor
+Author: Harshit Gangal
 Reviewers: 
 Status: 
-Created: 2024-10-29
+Created: 2024-11-02
 ```
 
 ## Abstract

--- a/veps/vep-6.md
+++ b/veps/vep-6.md
@@ -1,0 +1,38 @@
+# # VEP-6 Vitess Release cadence
+
+```
+VEP: 5
+Title: Vitess Release Cadence
+Author: Andres Taylor
+Reviewers: 
+Status: 
+Created: 2024-10-29
+```
+
+## Abstract
+
+[VEP-1](https://github.com/vitessio/enhancements/blob/main/veps/vep-1.md) established a support lifecycle for Vitess. [VEP-2](https://github.com/vitessio/enhancements/blob/main/veps/vep-2.md) later amended parts of it.
+[VEP-5](https://github.com/vitessio/enhancements/blob/main/veps/vep-5.md) modified the yearly major release to 3 and 1 year support for each major release, thus replaces the Support lifecycle section in VEP-1, and all of VEP-2.
+This VEP suggests a change to how often releases are made and its support lifecycle thus replacing all of VEP-5.
+
+All other sections of VEP-1 will continue to be in force without any change.
+
+## Versioning and Release Cadence
+
+The proposed release cycle is best described as _Monotonic Versioning_ with a release cadence similar to Kubernetes.
+The terminology `COMPATIBILITY.RELEASE` used in this document is directly sourced from the [Monotonic Versioning Manifesto](http://blog.appliedcompscilab.com/monotonic_versioning_manifesto/):
+
+1. The `COMPATIBILITY` number will be incremented every 6 months. For example, the next major release will have a `COMPATIBILITY` number of `22.0`.
+2. Each `COMPATIBILITY` number will be supported by the Open Source Vitess community for 12 months after the initial release.
+3. Patch releases will be created as needed. Patch releases will follow SemVer. The numbering scheme will be `COMPATIBILITY.PATCH_NUMBER`. For example, the first patch release on `22.0`, if there is one, will be `22.0.1`. `PATCH_NUMBER` will be monotonically increasing.
+4. Events that trigger patch releases are major regressions in functionality or performance, and CVEs.
+
+## Support Lifecycle
+The release cycle includes a new release every 6 months, most fixes will only be pushed to the main branch.
+An exception to this process will be made for high severity bugs.
+For these bug fixes, the fix will be applied to all supported release branches where the bug is manifested.
+
+Patch releases for supported versions are released at irregular intervals, depending on what has been fixed on the branch.
+
+High severity bugs in this context include CVEs, data corruption, wrong results or outage inducing issues. 
+The Vitess team may decide to only fix bugs in release branches with higher user impact.

--- a/veps/vep-6.md
+++ b/veps/vep-6.md
@@ -2,7 +2,7 @@
 
 ```
 VEP: 6
-Title: Vitess Release Cadence
+Title: Vitess Release Cycle
 Author: Harshit Gangal
 Reviewers: 
 Status: 

--- a/veps/vep-6.md
+++ b/veps/vep-6.md
@@ -13,7 +13,7 @@ Created: 2024-11-02
 
 [VEP-1](https://github.com/vitessio/enhancements/blob/main/veps/vep-1.md) established a support lifecycle for Vitess. [VEP-2](https://github.com/vitessio/enhancements/blob/main/veps/vep-2.md) later amended parts of it.
 [VEP-5](https://github.com/vitessio/enhancements/blob/main/veps/vep-5.md) changed the frequency of major releases to 3 per year and established a 1 year support cycle for each major release, thus replacing the Support Lifecycle section in VEP-1, and all of VEP-2.
-This VEP suggests a change to how often releases are made and its support lifecycle thus replacing all of VEP-5.
+This VEP proposes a change to how often releases are made thus replacing all of VEP-5.
 
 All other sections of VEP-1 will continue to be in force without any change.
 

--- a/veps/vep-6.md
+++ b/veps/vep-6.md
@@ -12,7 +12,7 @@ Created: 2024-11-02
 ## Abstract
 
 [VEP-1](https://github.com/vitessio/enhancements/blob/main/veps/vep-1.md) established a support lifecycle for Vitess. [VEP-2](https://github.com/vitessio/enhancements/blob/main/veps/vep-2.md) later amended parts of it.
-[VEP-5](https://github.com/vitessio/enhancements/blob/main/veps/vep-5.md) modified the yearly major release to 3 and 1 year support for each major release, thus replaces the Support lifecycle section in VEP-1, and all of VEP-2.
+[VEP-5](https://github.com/vitessio/enhancements/blob/main/veps/vep-5.md) changed the frequency of major releases to 3 per year and established a 1 year support cycle for each major release, thus replacing the Support Lifecycle section in VEP-1, and all of VEP-2.
 This VEP suggests a change to how often releases are made and its support lifecycle thus replacing all of VEP-5.
 
 All other sections of VEP-1 will continue to be in force without any change.

--- a/veps/vep-6.md
+++ b/veps/vep-6.md
@@ -19,8 +19,7 @@ All other sections of VEP-1 will continue to be in force without any change.
 
 ## Versioning and Release Cadence
 
-The proposed release cycle is best described as _Monotonic Versioning_ with a release cadence similar to Kubernetes.
-The terminology `COMPATIBILITY.RELEASE` used in this document is directly sourced from the [Monotonic Versioning Manifesto](http://blog.appliedcompscilab.com/monotonic_versioning_manifesto/):
+The proposed release cycle is best described as _Monotonic Versioning_, using the terminology `COMPATIBILITY.RELEASE` from the [Monotonic Versioning Manifesto](http://blog.appliedcompscilab.com/monotonic_versioning_manifesto/):
 
 1. The `COMPATIBILITY` number will be incremented every 6 months. For example, the next major release will have a `COMPATIBILITY` number of `22.0`.
 2. Each `COMPATIBILITY` number will be supported by the Open Source Vitess community for 12 months after the initial release.

--- a/veps/vep-6.md
+++ b/veps/vep-6.md
@@ -28,11 +28,10 @@ The terminology `COMPATIBILITY.RELEASE` used in this document is directly source
 4. Events that trigger patch releases are major regressions in functionality or performance, and CVEs.
 
 ## Support Lifecycle
-The release cycle includes a new release every 6 months, most fixes will only be pushed to the main branch.
-An exception to this process will be made for high severity bugs.
-For these bug fixes, the fix will be applied to all supported release branches where the bug is manifested.
+A new version is released every 6 months, with each version supported for 12 months. At any time, two versions are actively supported: the latest release and the one prior.
 
-Patch releases for supported versions are released at irregular intervals, depending on what has been fixed on the branch.
+Bug fixes are applied to the main branch, except for high-severity issues, which will be patched in all supported branches where the issue occurs.
 
-High severity bugs in this context include CVEs, data corruption, wrong results or outage inducing issues. 
-The Vitess team may decide to only fix bugs in release branches with higher user impact.
+Patch releases for these supported versions are released as needed, depending on the fixes available in each branch.
+
+High-severity issues in this context include CVEs, data corruption, incorrect results, or issues causing outages. The Vitess team may choose to prioritize bug fixes in branches with the highest user impact.

--- a/veps/vep-6.md
+++ b/veps/vep-6.md
@@ -4,8 +4,8 @@
 VEP: 6
 Title: Vitess Release Cycle
 Author: Harshit Gangal
-Reviewers: Derek Perkins, Deepthi Sigireddi, Florent Poinsard
-Status: Proposed
+Reviewers: Derek Perkins, Deepthi Sigireddi, Florent Poinsard, Matt Lord, Rohit Nayak
+Status: Approved
 Created: 2024-11-02
 ```
 
@@ -24,7 +24,7 @@ The proposed release cycle is best described as _Monotonic Versioning_, using th
 1. The `COMPATIBILITY` number will be incremented every 6 months. For example, the next major release will have a `COMPATIBILITY` number of `22.0`.
 2. Each `COMPATIBILITY` number will be supported by the Open Source Vitess community for 12 months after the initial release.
 3. Patch releases will be created as needed. Patch releases will follow SemVer. The numbering scheme will be `COMPATIBILITY.PATCH_NUMBER`. For example, the first patch release on `22.0`, if there is one, will be `22.0.1`. `PATCH_NUMBER` will be monotonically increasing.
-4. Events that trigger patch releases are major regressions in functionality or performance, and CVEs.
+4. Events that trigger patch releases are critical bugs, major regressions in functionality or performance, and CVEs.
 
 ## Support Lifecycle
 A new version is released every 6 months, with each version supported for 12 months. At any time, two versions are actively supported: the latest release and the one prior.

--- a/veps/vep-6.md
+++ b/veps/vep-6.md
@@ -4,8 +4,8 @@
 VEP: 6
 Title: Vitess Release Cycle
 Author: Harshit Gangal
-Reviewers: 
-Status: 
+Reviewers: Derek Perkins, Deepthi Sigireddi, Florent Poinsard
+Status: Proposed
 Created: 2024-11-02
 ```
 

--- a/veps/vep-6.md
+++ b/veps/vep-6.md
@@ -1,4 +1,4 @@
-# # VEP-6 Vitess Release cadence
+# # VEP-6 Vitess Release Cycle
 
 ```
 VEP: 6


### PR DESCRIPTION
This is changing the Vitess release cycle to 6 monthly giving 1 year of support for each release.